### PR TITLE
adapt tf executable rules to work with bazel 8

### DIFF
--- a/tf/rules/apply.bzl
+++ b/tf/rules/apply.bzl
@@ -30,16 +30,20 @@ def _impl(ctx):
     coreutils = ctx.toolchains["@aspect_bazel_lib//lib:coreutils_toolchain_type"].coreutils_info
     tf = ctx.toolchains["@rules_tf//:tf_toolchain_type"].runtime
 
+    tar_path = tar.tarinfo.binary.path.replace("external","..",1)
+    tf_path  = tf.exec.path.replace("external","..",1)
+    coreutils_path = coreutils.bin.path.replace("external","..",1)
+
     launcher = ctx.actions.declare_file("apply_%s.sh" % ctx.label.name)
 
     script = _TF_SCRIPT.format(
         tf_init_tar = tf_init_tar_path,
-        tar_path = "tar" if ctx.attr.system_utils else tar.tarinfo.binary.path,
-        tf_path = tf.exec.path,
+        tar_path = "tar" if ctx.attr.system_utils else tar_path,
+        tf_path = tf_path,
         tf_parallelism = ctx.attr.parallelism,
         tf_dir = ctx.label.package,
         tf_plan = tf_plan_file.basename,
-        coreutils_path = "" if ctx.attr.system_utils else coreutils.bin.path,
+        coreutils_path = "" if ctx.attr.system_utils else coreutils_path,
     )
 
     ctx.actions.write(
@@ -78,7 +82,7 @@ tf_apply = rule(
             default = "10",
         ),
         "system_utils": attr.bool(
-            default = True,
+            default = False,
         ),
     },
     toolchains = [

--- a/tf/rules/binary.bzl
+++ b/tf/rules/binary.bzl
@@ -7,17 +7,23 @@ load("//tf/rules:providers.bzl", "TerraformInitInfo")
 _TF_SCRIPT = """#!/usr/bin/env bash
 set -o pipefail -o errexit -o nounset
 
-{tar_path} -C {tf_dir} -xzf {tf_init_tar}
+{tar_cmd}
 {tf_cmd} "$@"
 """
 
 def _impl(ctx):
-    tf_init_tar = ctx.attr.init[TerraformInitInfo].init_archive
-
-    tf_init_tar_path = tf_init_tar.path.removeprefix(ctx.bin_dir.path + "/")
-
     tar = ctx.toolchains["@aspect_bazel_lib//lib:tar_toolchain_type"]
+    tar_path = tar.tarinfo.binary.path.replace("external","..",1)
+    tar_cmd = ""
+    tf_init_tar_path = ""
+
+    if ctx.attr.init:
+        tf_init_tar = ctx.attr.init[TerraformInitInfo].init_archive
+        tf_init_tar_path = tf_init_tar.path.removeprefix(ctx.bin_dir.path + "/")
+        tar_cmd = "{tar_path} -C {tf_dir} -xzf {tf_init_tar_path}"
+
     tf = ctx.toolchains["@rules_tf//:tf_toolchain_type"].runtime
+    tf_path = tf.exec.path.replace("external","..",1)
 
     tf_cmd = "{tf_path}"
 
@@ -27,11 +33,13 @@ def _impl(ctx):
     launcher = ctx.actions.declare_file("bin_%s.sh" % ctx.label.name)
 
     script = _TF_SCRIPT.format(
-        tf_init_tar = tf_init_tar_path,
-        tar_path = "tar" if ctx.attr.system_utils else tar.tarinfo.binary.path,
-        tf_dir = ctx.label.package,
+        tar_cmd = tar_cmd.format(
+            tf_init_tar_path = tf_init_tar_path,
+            tar_path = "tar" if ctx.attr.system_utils else tar_path,
+            tf_dir = ctx.label.package,
+        ),
         tf_cmd = tf_cmd.format(
-            tf_path = tf.exec.path,
+            tf_path = tf_path,
             tf_dir = ctx.label.package,
         ),
     )
@@ -60,7 +68,6 @@ tf_binary = rule(
             allow_files = True,
         ),
         "init": attr.label(
-            mandatory = True,
             providers = [TerraformInitInfo],
         ),
         "system_utils": attr.bool(

--- a/tf/rules/fmt.bzl
+++ b/tf/rules/fmt.bzl
@@ -5,6 +5,7 @@ This module contains test rules for tf fmt.
 def _impl(ctx):
     launcher = ctx.actions.declare_file("fmt_%s.sh" % ctx.label.name)
     tf = ctx.toolchains["@rules_tf//:tf_toolchain_type"].runtime
+    tf_path = tf.exec.path.replace("external","..",1)
 
     args = "fmt -recursive -check"
     if not ctx.attr.testonly:
@@ -13,7 +14,7 @@ def _impl(ctx):
         )
 
     cmd = "{tf} {args}".format(
-        tf = tf.exec.path,
+        tf = tf_path,
         args = args,
     )
 

--- a/tf/rules/validate.bzl
+++ b/tf/rules/validate.bzl
@@ -18,13 +18,15 @@ def _impl(ctx):
 
     tar = ctx.toolchains["@aspect_bazel_lib//lib:tar_toolchain_type"]
     tf = ctx.toolchains["@rules_tf//:tf_toolchain_type"].runtime
+    tar_path = tar.tarinfo.binary.path.replace("external","..",1)
+    tf_path  = tf.exec.path.replace("external","..",1)
 
     launcher = ctx.actions.declare_file("validate_%s.sh" % ctx.label.name)
 
     script = _TF_SCRIPT.format(
         tf_init_tar = tf_init_tar_path,
-        tar_path = "tar" if ctx.attr.system_utils else tar.tarinfo.binary.path,
-        tf_path = tf.exec.path,
+        tar_path = "tar" if ctx.attr.system_utils else tar_path,
+        tf_path = tf_path,
         tf_dir = ctx.label.package,
     )
 


### PR DESCRIPTION
* Adapt path to external runfile in bazel rule due to this flag flip https://github.com/bazelbuild/bazel/issues/23574 in Bazel 8
* set apply rule `system_utils` attr  default value to false
* binary rule `init` attribute is not mandatory anymore